### PR TITLE
Add canvas-based LLM learning game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Solo Awakening LLM Game
+
+A small HTML5 canvas game that introduces the basic steps of building a tiny language model.
+
+## How to Play
+
+1. Open `index.html` in your browser.
+2. Use the arrow keys to move the blue square.
+3. Collect all green tokens. Each token explains a step in building a language model.
+4. After collecting every token, a tiny bigram model is trained on a small sample of text and generates new text.
+
+This project is a playful way to understand concepts like data collection, tokenization, training, and text generation.

--- a/game.js
+++ b/game.js
@@ -1,0 +1,110 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+
+const player = { x: 300, y: 200, size: 20, speed: 3 };
+
+const tokens = [
+  { x: 80, y: 80, radius: 10, message: 'Collect data: gather text!' },
+  { x: 520, y: 90, radius: 10, message: 'Tokenize: split text into pieces!' },
+  { x: 120, y: 320, radius: 10, message: 'Train: learn from tokens!' },
+  { x: 470, y: 270, radius: 10, message: 'Generate: create new text!' }
+];
+
+let keys = {};
+let collectedCount = 0;
+
+function drawPlayer() {
+  ctx.fillStyle = 'blue';
+  ctx.fillRect(player.x - player.size / 2, player.y - player.size / 2, player.size, player.size);
+}
+
+function drawTokens() {
+  ctx.fillStyle = 'green';
+  tokens.forEach(t => {
+    if (!t.collected) {
+      ctx.beginPath();
+      ctx.arc(t.x, t.y, t.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  });
+}
+
+function movePlayer() {
+  if (keys['ArrowUp']) player.y -= player.speed;
+  if (keys['ArrowDown']) player.y += player.speed;
+  if (keys['ArrowLeft']) player.x -= player.speed;
+  if (keys['ArrowRight']) player.x += player.speed;
+
+  player.x = Math.max(player.size / 2, Math.min(canvas.width - player.size / 2, player.x));
+  player.y = Math.max(player.size / 2, Math.min(canvas.height - player.size / 2, player.y));
+}
+
+function checkCollisions() {
+  tokens.forEach(t => {
+    if (!t.collected) {
+      const dx = player.x - t.x;
+      const dy = player.y - t.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (distance < player.size / 2 + t.radius) {
+        t.collected = true;
+        collectedCount++;
+        alert(t.message);
+        if (collectedCount === tokens.length) {
+          trainAndGenerate();
+        }
+      }
+    }
+  });
+}
+
+function loop() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  movePlayer();
+  drawPlayer();
+  drawTokens();
+  checkCollisions();
+  requestAnimationFrame(loop);
+}
+
+function trainBigramModel(text) {
+  const model = {};
+  for (let i = 0; i < text.length - 1; i++) {
+    const ch1 = text[i];
+    const ch2 = text[i + 1];
+    if (!model[ch1]) model[ch1] = {};
+    model[ch1][ch2] = (model[ch1][ch2] || 0) + 1;
+  }
+  return model;
+}
+
+function generateText(model, start, length) {
+  let result = start;
+  let current = start;
+  for (let i = 0; i < length; i++) {
+    const nextOptions = model[current];
+    if (!nextOptions) break;
+    const total = Object.values(nextOptions).reduce((a, b) => a + b, 0);
+    let r = Math.random() * total;
+    for (const [char, count] of Object.entries(nextOptions)) {
+      r -= count;
+      if (r <= 0) {
+        result += char;
+        current = char;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+function trainAndGenerate() {
+  const sample = 'hello world. the world is full of words. learn and build models.';
+  const model = trainBigramModel(sample);
+  const text = generateText(model, 'h', 80);
+  alert('Tiny model says:\n' + text);
+}
+
+window.addEventListener('keydown', e => keys[e.key] = true);
+window.addEventListener('keyup', e => keys[e.key] = false);
+
+loop();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>LLM Learning Game</title>
+  <style>
+    canvas {
+      background: #f0f0f0;
+      display: block;
+      margin: 0 auto;
+      border: 1px solid #000;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="gameCanvas" width="600" height="400"></canvas>
+  <script src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce HTML5 canvas game teaching the steps to build a tiny language model
- Implement basic player movement and token collection revealing LLM concepts
- Train a simple bigram model and generate sample text upon completion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895894e0f3c832088982993cdad666e